### PR TITLE
Rename the key from "dns" to "domainNameServers".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 all: pylint test
 
 pylint:
-	flake8 -v .
+	flake8 -v --exclude=.git,__init__.py .
 test:
-	nosetests --with-coverage --cover-erase --cover-package=dhcpd
+	nosetests --with-coverage --cover-erase --cover-package=dhcpd -v
 
 .PHONY: pylint test

--- a/data/dhcpd.json.factory
+++ b/data/dhcpd.json.factory
@@ -7,7 +7,7 @@
 			"netmask": "",
 			"startIP": "",
 			"endIP": "",
-			"dns": [],
+			"domainNameServers": [],
 			"name": "eth0",
 			"domainName": "",
 			"leaseTime": "3600"
@@ -19,7 +19,7 @@
 			"netmask": "",
 			"startIP": "",
 			"endIP": "",
-			"dns": [],
+			"domainNameServers": [],
 			"name": "eth1",
 			"domainName": "",
 			"leaseTime": "3600"
@@ -31,7 +31,7 @@
 			"netmask": "",
 			"startIP": "",
 			"endIP": "",
-			"dns": [],
+			"domainNameServers": [],
 			"name": "eth2",
 			"domainName": "",
 			"leaseTime": "3600"
@@ -43,7 +43,7 @@
 			"netmask": "",
 			"startIP": "",
 			"endIP": "",
-			"dns": [],
+			"domainNameServers": [],
 			"name": "eth3",
 			"domainName": "",
 			"leaseTime": "3600"

--- a/template/subnet
+++ b/template/subnet
@@ -3,7 +3,7 @@ subnet ${subnet} netmask ${netmask} {
 	range ${startIP} ${endIP};
 	default-lease-time ${leaseTime};
 	max-lease-time ${leaseTime};
-	${domainNameServers}
+	option domain-name-servers ${domainNameServers};
 	option domain-name "${domainName}";
 	option routers ${routers};
 }

--- a/tests/test_dhcpd.py
+++ b/tests/test_dhcpd.py
@@ -10,6 +10,7 @@ import subprocess
 
 from sanji.connection.mockup import Mockup
 from sanji.message import Message
+
 from mock import patch
 from string import Template
 from mock import Mock
@@ -22,6 +23,9 @@ try:
     sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../')
     from dhcpd import Dhcpd
 except ImportError as e:
+    print os.path.dirname(os.path.realpath(__file__)) + '/../'
+    print sys.path
+    print e
     print "Please check the python PATH for import test module. (%s)" \
         % __file__
     exit(1)
@@ -181,7 +185,8 @@ class TestDhcpdClass(unittest.TestCase):
 
         message = Message({"data": {"id": 1, "name": "eth0", "enable": 1,
                                     "subnet": "", "netmask": "",
-                                    "startIP": "", "endIP": "", "dns": [],
+                                    "startIP": "", "endIP": "",
+                                    "domainNameServers": [],
                                     "domainName": "", "leaseTime": "3600"},
                           "query": {}, "param": {"id": 1}})
         update_db.side_effect = Exception("update_db failed")
@@ -200,7 +205,8 @@ class TestDhcpdClass(unittest.TestCase):
 
         message = Message({"data": {"id": 1, "name": "eth0", "enable": 1,
                                     "subnet": "", "netmask": "",
-                                    "startIP": "", "endIP": "", "dns": [],
+                                    "startIP": "", "endIP": "",
+                                    "domainNameServers": [],
                                     "domainName": "", "leaseTime": "3600"},
                           "query": {}, "param": {"id": 1}})
 
@@ -223,7 +229,8 @@ class TestDhcpdClass(unittest.TestCase):
 
         message = Message({"data": {"id": 1, "name": "eth0", "enable": 1,
                                     "subnet": "", "netmask": "",
-                                    "startIP": "", "endIP": "", "dns": [],
+                                    "startIP": "", "endIP": "",
+                                    "domainNameServers": [],
                                     "domainName": "", "leaseTime": "3600"},
                           "query": {}, "param": {"id": 1}})
 
@@ -247,7 +254,8 @@ class TestDhcpdClass(unittest.TestCase):
 
         message = Message({"data": {"id": 1, "name": "eth0", "enable": 1,
                                     "subnet": "", "netmask": "",
-                                    "startIP": "", "endIP": "", "dns": [],
+                                    "startIP": "", "endIP": "",
+                                    "domainNameServers": [],
                                     "domainName": "", "leaseTime": "3600"},
                           "query": {}, "param": {"id": 1}})
 
@@ -331,10 +339,8 @@ class TestDhcpdClass(unittest.TestCase):
                     "leaseTime": "5566",
                     "endIP": "192.168.10.50",
                     "startIP": "192.168.10.10",
-                    "dns": ["1.1.1.1", "2.2.2.2", "3.3.3.3"],
+                    "domainNameServers": ["1.1.1.1", "2.2.2.2", "3.3.3.3"],
                     "domainName": "MXcloud115",
-                    "domainNameServers":
-                    "option domain-name-servers 8.8.8.8;",
                     "netmask": "255.255.0.0",
                     "routers": "192.168.31.115",
                 }
@@ -444,10 +450,8 @@ class TestDhcpdClass(unittest.TestCase):
                     "leaseTime": "5566",
                     "endIP": "192.168.10.50",
                     "startIP": "192.168.10.10",
-                    "dns": ["1.1.1.1", "2.2.2.2", "3.3.3.3"],
+                    "domainNameServers": ["1.1.1.1", "2.2.2.2", "3.3.3.3"],
                     "domainName": "MXcloud115",
-                    "domainNameServers":
-                    "option domain-name-servers 8.8.8.8;",
                     "netmask": "255.255.0.0",
                     "routers": "192.168.31.115",
                 }


### PR DESCRIPTION
Bug fixed: after 1st setting, the dns will be replaced by
domainNameServers and the content will also be changed by dhcpd's
configuration format. Invalid schema happens everytime when user try to
"put".